### PR TITLE
Adding forward slash to end of directory import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.8.2
+------------------------------
+*January 26, 2018*
+
+### Added
+- Forward slash to end of directory import, due to breaking build in TeamCity.
 
 v0.8.1
 ------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-validate",
   "description": "Fozzie vanilla JS Validation Component",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "dist/index.js",
   "homepage": "https://github.com/justeat/f-validate",
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import testDefinitions from './rules';
+import testDefinitions from './rules/';
 import { addCallBack, runCallbacks } from './callbacks';
 import { getInlineErrorElement, displayInlineMessage, hideMessage, getMessage } from './messages';
 import CONSTANTS from './constants';


### PR DESCRIPTION
### Added
- Forward slash to end of directory import, due to breaking build in TeamCity.

## UI Review Checks

- [x] UI Documentation has been [created|updated]
- [ ] JavaScript Tests have been [created|updated]
- [ ] Module has been tested in Global Documentation

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)
