### PR TITLE
v0.12.0 - Validation groups changed, test updated and fix to validateOn

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ _A short description of your PR goes here._
 
 ## UI Review Checks
 
-![image](https://media.github.je-labs.com/user/326/files/c1e6632c-e23e-11e6-91e2-4625e4f89d6d)
+![image](https://user-images.githubusercontent.com/805184/35801356-f756b018-0a63-11e8-8ca4-ec045d43c16c.png)
 
 - [ ] UI Documentation has been [created|updated]
 - [ ] JavaScript Tests have been [created|updated]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.12.0
+------------------------------
+*February 19, 2018*
+
+### Fixed
+- Fixed issue with `validateOn` marking form as valid when `blur` event fired due to validating child elements inside groups
+- Readme typo
+
+### Added
+- Constant `validationGroup` added that defines the data-attribute for group validation elements
+
+### Changed
+- Pull request image updated
+- Updated how validation groups get assigned.  Now uses the data-attribute `data-val-group` rather than the class `validation-group` as modules should use attributes for hook definitions.
+- Some of the tests updated so that they are a bit clearer in their definition.  Stubbed date has changed to 2018 in the tests (as it was a bit confusing testing against a future date)
+
+
 v0.11.0
 ------------------------------
 *February 7, 2018*

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ yarn add @justeat/f-validate
 Then, inside your script import and run `f-validate`.
 
 ```js
-import toggle from '@justeat/f-validate';
+import validate from '@justeat/f-validate';
 
 //to be confirmed
 ```

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,14 +3,16 @@ const cssClasses = {
     formError: 'form-error',
     formErrors: 'form-errors',
     hasError: 'has-error',
-    hasSuccess: 'has-success',
-    validationGroup: 'validation-group'
+    hasSuccess: 'has-success'
 };
+
+const validationGroup = 'data-val-group';
 
 export default {
     cssClasses,
     email: /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/,
     escapeChars: /[|\\{}()[\]^$+*?.]/g,
-    fieldValues: `input, select, textarea, .${cssClasses.validationGroup}`,
+    fieldValues: `input, select, textarea, [${validationGroup}]`,
+    validationGroup,
     validateOnOptions: ['blur', 'keyup']
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,27 @@
+/**
+ * @module Validate
+ *
+ * ## Goals
+ *
+ * To validate a form based on the HTML5 attributes each form has, or the data attributes specified on them
+ *
+ * Should accept either:
+ *
+ * 1. A form DOM Element
+ * 2. A string relating to the name of the form
+ *
+ * Should also be able to label a form field with `data-novalidate`
+ * to remove it from those being validated
+ *
+ */
+
 import $ from '@justeat/f-dom';
 import testDefinitions from './rules';
 import { addCallBack, runCallbacks } from './callbacks';
 import { getInlineErrorElement, displayInlineMessage, hideMessage, getMessage } from './messages';
 import CONSTANTS from './constants';
 
+// Load in the set of test definitions to validate against
 const VALIDATION_KEYS = Object.keys(testDefinitions);
 
 export const defaultOptions = {
@@ -216,7 +234,8 @@ export default class FormValidation {
             .filter(f => !(f.hasAttribute('type')
                 && f.getAttribute('type') === 'hidden')
                 && !f.hasAttribute('disabled')
-                && !f.hasAttribute('data-novalidate'));
+                && !f.hasAttribute('data-novalidate')
+                && !f.parentElement.hasAttribute(CONSTANTS.validationGroup));
     }
 
     findGroupedErrorElement () {
@@ -265,7 +284,8 @@ export default class FormValidation {
     }
 
     /**
-     * validateOn - Validates form fields based on event passed into options.validateOn
+     * Validates form field(s) based on the event passed into options.validateOn
+     *
      * example:
      *       this.validation = new FormValidation(this.form, {
      *           validateOn: 'blur'
@@ -282,7 +302,7 @@ export default class FormValidation {
         }
 
         this.fields.forEach(field => {
-            if (field.classList.contains(CONSTANTS.cssClasses.validationGroup)) {
+            if (field.hasAttribute(CONSTANTS.validationGroup)) {
                 field.querySelectorAll(CONSTANTS.fieldValues).forEach(childField =>
 
                     // Binds each form element within a validation-group to the specified event.
@@ -293,7 +313,9 @@ export default class FormValidation {
                         this.isValid.bind(this, null, {
                             field,
                             childField
-                        })));
+                        })
+                    )
+                );
 
             } else {
                 // Null is being passed as the isValid method expects 'field' as its second argument

--- a/test/__snapshots__/validateOn.test.js.snap
+++ b/test/__snapshots__/validateOn.test.js.snap
@@ -13,9 +13,9 @@ exports[`validateOn blur should not validate if field is empty 1`] = `
                                     </form>"
 `;
 
-exports[`validateOn blur should set form state to invalid, as first select has been touched 1`] = `
-"<form class=\\"has-success\\">
-                                <div class=\\"validation-group has-error\\" data-val-dateinfuture=\\"\\">
+exports[`validateOn blur should set form state to invalid, as first select has been touched and no option selected 1`] = `
+"<form class=\\"has-error\\">
+                                <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-error\\">
                                      <select data-val-dateinfuture-type=\\"year\\" data-touched=\\"true\\">
                                         <option value=\\"\\"></option>
                                     </select>
@@ -27,12 +27,14 @@ exports[`validateOn blur should set form state to invalid, as first select has b
                             </form>"
 `;
 
-exports[`validateOn blur should set form state to invalid, as second select has been touched 1`] = `
-"<form class=\\"has-success\\">
-                                <div class=\\"validation-group has-error\\" data-val-dateinfuture=\\"\\">
+exports[`validateOn blur should set form state to invalid, as second select has been touched and no value selected 1`] = `
+"<form class=\\"has-error\\">
+                                <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-error\\">
                                      <select data-val-dateinfuture-type=\\"year\\" data-touched=\\"true\\">
                                         <option value=\\"\\"></option>
-                                        <option value=\\"2021\\" selected=\\"\\"></option>
+                                        <option value=\\"2018\\"></option>
+                                        <option value=\\"2019\\"></option>
+                                        <option value=\\"2020\\" selected=\\"\\"></option>
                                     </select>
                                     <select data-val-dateinfuture-type=\\"month\\" data-touched=\\"true\\">
                                         <option value=\\"\\"></option>
@@ -41,9 +43,9 @@ exports[`validateOn blur should set form state to invalid, as second select has 
                             </form>"
 `;
 
-exports[`validateOn blur should set form state to valid, as first select has not been touched 1`] = `
+exports[`validateOn blur should set form state to valid, as first select has not been touched yet 1`] = `
 "<form class=\\"has-success\\">
-                                <div class=\\"validation-group has-success\\" data-val-dateinfuture=\\"\\">
+                                <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-success\\">
                                      <select data-val-dateinfuture-type=\\"year\\">
                                         <option value=\\"\\"></option>
                                     </select>
@@ -57,10 +59,12 @@ exports[`validateOn blur should set form state to valid, as first select has not
 
 exports[`validateOn blur should set form state to valid, as second select has not been touched 1`] = `
 "<form class=\\"has-success\\">
-                                <div class=\\"validation-group has-success\\" data-val-dateinfuture=\\"\\">
+                                <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-success\\">
                                      <select data-val-dateinfuture-type=\\"year\\" data-touched=\\"true\\">
                                         <option value=\\"\\"></option>
-                                        <option value=\\"2021\\" selected=\\"\\"></option>
+                                        <option value=\\"2018\\"></option>
+                                        <option value=\\"2019\\"></option>
+                                        <option value=\\"2020\\" selected=\\"\\"></option>
                                     </select>
                                     <select data-val-dateinfuture-type=\\"month\\">
                                         <option value=\\"\\"></option>

--- a/test/constants.test.js
+++ b/test/constants.test.js
@@ -9,7 +9,6 @@ describe('CONSTANTS', () => {
         expect(CONSTANTS.cssClasses).toHaveProperty('formErrors', 'form-errors');
         expect(CONSTANTS.cssClasses).toHaveProperty('hasError', 'has-error');
         expect(CONSTANTS.cssClasses).toHaveProperty('hasSuccess', 'has-success');
-        expect(CONSTANTS.cssClasses).toHaveProperty('validationGroup', 'validation-group');
 
     });
 
@@ -27,7 +26,11 @@ describe('CONSTANTS', () => {
         expect(values).toContain('input');
         expect(values).toContain('select');
         expect(values).toContain('textarea');
-        expect(values).toContain('.validation-group');
+        expect(values).toContain('[data-val-group]');
+    });
+
+    it('should contain validationGroup', () => {
+        expect(CONSTANTS.validationGroup).toEqual('data-val-group');
     });
 
     it('should contain blur and keyup within validateOnOptions', () => {

--- a/test/rules/dateInFuture.test.js
+++ b/test/rules/dateInFuture.test.js
@@ -4,21 +4,52 @@ import stubDate from '../helpers/stubDate';
 
 describe('dateInFuture validation rules', () => {
 
-    stubDate('Oct 16, 2020');
+    // Represents the current date to test against
+    stubDate('Oct 16, 2018');
 
-    it('should return true if year selected is beyond current year', () => {
+    it('should return invalid if both year and month are untouched', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
-                                <div class="validation-group"
+                                <div data-val-group
                                     data-val-dateinfuture>
                                      <select data-val-dateinfuture-type="year">
                                         <option value="" ></option>
-                                        <option value="2021" selected></option>
+                                        <option value="2018">2018</option>
                                     </select>
                                     <select data-val-dateinfuture-type="month">
                                         <option value="" ></option>
-                                        <option value="01" selected></option>
+                                        <option value="01">01</option>
+                                    </select>
+                                </div>
+                            </form>`);
+
+        const form = document.querySelector('form');
+        const validateForm = new FormValidation(form);
+
+        // Act
+        const isFormValid = validateForm.isValid();
+
+        // Assert
+        expect(isFormValid).toBe(false);
+
+    });
+
+    it('should return valid if year selected is beyond current year', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form>
+                                <div data-val-group
+                                    data-val-dateinfuture>
+                                     <select data-val-dateinfuture-type="year">
+                                        <option value="" ></option>
+                                        <option value="2018">2018</option>
+                                        <option value="2019">2019</option>
+                                        <option value="2020" selected>2020</option>
+                                    </select>
+                                    <select data-val-dateinfuture-type="month">
+                                        <option value="" ></option>
+                                        <option value="01" selected>01</option>
                                     </select>
                                 </div>
                             </form>`);
@@ -34,19 +65,21 @@ describe('dateInFuture validation rules', () => {
 
     });
 
-    it('should return true if year selected is current year, and month is current month', () => {
+    it('should return valid if year selected is current year, and month is current month', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
-                                    <div class="validation-group"
+                                    <div data-val-group
                                         data-val-dateinfuture>
                                     <select data-val-dateinfuture-type="year">
                                         <option value="" ></option>
-                                        <option value="2020" selected></option>
+                                        <option value="2018" selected>2018</option>
+                                        <option value="2019">2019</option>
+                                        <option value="2020">2020</option>
                                     </select>
                                     <select data-val-dateinfuture-type="month">
                                         <option value="" ></option>
-                                        <option value="10" selected></option>
+                                        <option value="10" selected>10</option>
                                     </select>
                                 </div>
                             </form>`);
@@ -62,19 +95,21 @@ describe('dateInFuture validation rules', () => {
 
     });
 
-    it('should return true if year selected is current year, and month selected is future month', () => {
+    it('should return valid if year selected is current year, and month selected is future month', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
-                                    <div class="validation-group"
+                                    <div data-val-group
                                         data-val-dateinfuture>
                                         <select data-val-dateinfuture-type="year">
                                             <option value="" ></option>
-                                            <option value="2020" selected></option>
+                                            <option value="2018" selected>2018</option>
+                                            <option value="2019">2019</option>
+                                            <option value="2020">2020</option>
                                         </select>
                                         <select data-val-dateinfuture-type="month">
                                             <option value="" ></option>
-                                            <option value="11" selected></option>
+                                            <option value="11" selected>11</option>
                                         </select>
                                     </div>
                                 </form>`);
@@ -90,19 +125,21 @@ describe('dateInFuture validation rules', () => {
 
     });
 
-    it('should return false if year selected is current year, and month selected is previous month', () => {
+    it('should return invalid if year selected is current year, and month selected is previous month', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
-                                <div class="validation-group"
+                                <div data-val-group
                                     data-val-dateinfuture>
                                     <select data-val-dateinfuture-type="year">
                                         <option value="" ></option>
-                                        <option value="2020" selected></option>
+                                        <option value="2018" selected>2018</option>
+                                        <option value="2019">2019</option>
+                                        <option value="2020">2020</option>
                                     </select>
                                     <select data-val-dateinfuture-type="month">
                                         <option value="" ></option>
-                                        <option value="9" selected></option>
+                                        <option value="9" selected>9</option>
                                     </select>
                                 </div>
                             </form>`);
@@ -122,11 +159,13 @@ describe('dateInFuture validation rules', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
-                                <div class="validation-group"
+                                <div data-val-group
                                     data-val-dateinfuture>
                                     <select data-val-dateinfuture-type="year">
                                         <option value="" ></option>
-                                        <option value="2021" selected></option>
+                                        <option value="2018">2018</option>
+                                        <option value="2019" selected>2019</option>
+                                        <option value="2020">2020</option>
                                     </select>
                                     <select data-val-dateinfuture-type="month">
                                         <option value="" ></option>

--- a/test/rules/matches.test.js
+++ b/test/rules/matches.test.js
@@ -4,7 +4,7 @@ import FormValidation from '../../src';
 
 describe('matches fields', () => {
 
-    it('should return invalid for a field with "equalto" attribute, that does not match value of specified field', () => {
+    it('should return invalid for a field with "equalto" attribute, that does not match the value of specified field', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
@@ -22,7 +22,7 @@ describe('matches fields', () => {
 
     });
 
-    it('should return invalid for a field with "equalto" attribute, that matches value, but field is not specified', () => {
+    it('should return invalid for a field with "equalto" attribute, but a field is not specified in that attribute', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
@@ -40,7 +40,7 @@ describe('matches fields', () => {
 
     });
 
-    it('should return invalid for a field with "equalto" attribute, that does matches value, but field does not exist', () => {
+    it('should return invalid for a field with "equalto" attribute, but the field specified does not exist', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>
@@ -57,7 +57,7 @@ describe('matches fields', () => {
 
     });
 
-    it('should return valid for a field with "equalto" attribute, that does match value of specified field', () => {
+    it('should return valid for an input field with "equalto" attribute, that does match the value of specified field', () => {
 
         // Arrange
         TestUtils.setBodyHtml(`<form>

--- a/test/validateOn.test.js
+++ b/test/validateOn.test.js
@@ -97,15 +97,17 @@ describe('validateOn', () => {
 
         it('should set form state to valid, as second select has not been touched', () => {
 
-            stubDate('Oct 16, 2020');
+            stubDate('Oct 16, 2018');
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
-                                <div class="validation-group"
+                                <div data-val-group
                                     data-val-dateinfuture>
                                      <select data-val-dateinfuture-type="year">
                                         <option value="" ></option>
-                                        <option value="2021" selected></option>
+                                        <option value="2018"></option>
+                                        <option value="2019"></option>
+                                        <option value="2020" selected></option>
                                     </select>
                                     <select data-val-dateinfuture-type="month">
                                         <option value="" ></option>
@@ -129,17 +131,19 @@ describe('validateOn', () => {
 
         });
 
-        it('should set form state to invalid, as second select has been touched', () => {
+        it('should set form state to invalid, as second select has been touched and no value selected', () => {
 
-            stubDate('Oct 16, 2020');
+            stubDate('Oct 16, 2018');
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
-                                <div class="validation-group"
+                                <div data-val-group
                                     data-val-dateinfuture>
                                      <select data-val-dateinfuture-type="year">
                                         <option value="" ></option>
-                                        <option value="2021" selected></option>
+                                        <option value="2018"></option>
+                                        <option value="2019"></option>
+                                        <option value="2020" selected></option>
                                     </select>
                                     <select data-val-dateinfuture-type="month" data-touched="true">
                                         <option value="" ></option>
@@ -163,13 +167,13 @@ describe('validateOn', () => {
 
         });
 
-        it('should set form state to valid, as first select has not been touched', () => {
+        it('should set form state to valid, as first select has not been touched yet', () => {
 
-            stubDate('Oct 16, 2020');
+            stubDate('Oct 16, 2018');
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
-                                <div class="validation-group"
+                                <div data-val-group
                                     data-val-dateinfuture>
                                      <select data-val-dateinfuture-type="year">
                                         <option value="" ></option>
@@ -197,13 +201,13 @@ describe('validateOn', () => {
 
         });
 
-        it('should set form state to invalid, as first select has been touched', () => {
+        it('should set form state to invalid, as first select has been touched and no option selected', () => {
 
-            stubDate('Oct 16, 2020');
+            stubDate('Oct 16, 2018');
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
-                                <div class="validation-group"
+                                <div data-val-group
                                     data-val-dateinfuture>
                                      <select data-val-dateinfuture-type="year" data-touched="true">
                                         <option value="" ></option>


### PR DESCRIPTION
### Fixed
- Fixed issue with `validateOn` marking form as valid when `blur` event fired due to validating child elements inside groups
- Readme typo

### Added
- Constant `validationGroup` added that defines the data-attribute for group validation elements

### Changed
- Pull request image updated
- Updated how validation groups get assigned.  Now uses the data-attribute `data-val-group` rather than the class `validation-group` as modules should use attributes for hook definitions.
- Some of the tests updated so that they are a bit clearer in their definition.  Stubbed date has changed to 2018 in the tests (as it was a bit confusing testing against a future date)