### PR TITLE
v0.13.0 - `novalidate` added to form & test updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v0.13.0
+------------------------------
+*February 23, 2018*
+
+### Changed
+- Have made it the default behaviour to set the `novalidate` attribute on a form when `f-validate` is initialised on it.  This can be overidden if the developer wants to allow the default HTML5 validation to kick in by setting the `enableHTML5Validation` option to true.
+- Custom error attributes changed so that they are in the format `data-val-` as they weren't consistent.
+- Updated some of the test descriptions on error messages to be a little clearer as to the expected functionality.  Re-jigged the ordering as well, so that the default rules come first.
+- Snapshots updated with the above changes.
+
+
 v0.12.0
 ------------------------------
 *February 19, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-validate",
   "description": "Fozzie vanilla JS Validation Component",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,8 @@ export const defaultOptions = {
     errorClass: CONSTANTS.cssClasses.hasError,
     successClass: CONSTANTS.cssClasses.hasSuccess,
     focus: false,
-    groupErrorPlacement: false
+    groupErrorPlacement: false,
+    enableHTML5Validation: false
 };
 
 const getForm = descriptor => {
@@ -65,10 +66,11 @@ export default class FormValidation {
     constructor (nameOrNode, options = {}) {
         this.options = Object.assign({}, defaultOptions, options);
         this.form = getForm(nameOrNode);
-        this.form.addEventListener('submit', this.isValid.bind(this));
         this.fields = this.getFields();
         this.customHandlers = {};
         this.callBacks = {};
+        this.errorMessages = [];
+
         if (this.options.onSuccess) {
             this.on('success', this.options.onSuccess);
         }
@@ -78,7 +80,9 @@ export default class FormValidation {
         if (this.options.validateOn) {
             this.validateOn();
         }
-        this.errorMessages = [];
+
+        this.setFormNoValidate();
+        this.form.addEventListener('submit', this.isValid.bind(this));
     }
 
     /**
@@ -114,6 +118,14 @@ export default class FormValidation {
     setError (element) {
         element.classList.remove(this.options.successClass);
         element.classList.add(this.options.errorClass);
+    }
+
+    setFormNoValidate () {
+
+        if (!this.options.enableHTML5Validation) {
+            this.form.setAttribute('novalidate', '');
+        }
+
     }
 
     /**
@@ -179,6 +191,7 @@ export default class FormValidation {
                     this.setError(field);
                 }
 
+                // if we aren't handling a group field validation
                 if (!this.options.groupErrorPlacement) {
                     const errorElement = getInlineErrorElement(field, this.form);
                     if (fieldValid) {

--- a/src/messages.js
+++ b/src/messages.js
@@ -66,6 +66,6 @@ const getDefaultMessage = (field, ruleName) => {
         .defaultMessageValue(field));
 };
 
-export const getMessage = (field, ruleName) => field.getAttribute(`data-${ruleName}-error`)
+export const getMessage = (field, ruleName) => field.getAttribute(`data-val-${ruleName}-error`)
     || getDefaultMessage(field, ruleName);
 

--- a/test/__snapshots__/errorMessages.test.js.snap
+++ b/test/__snapshots__/errorMessages.test.js.snap
@@ -1,103 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`error messages custom positioning on field should create a new error message after specified element 1`] = `
-"<form class=\\"has-error\\">
-                                        <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
-                                        <input required=\\"\\" data-val-error-placement=\\".arbitrary-element\\" class=\\"has-error\\">
-                                        <span class=\\"arbitrary-element\\">arbitrary info text</span><p class=\\"form-error\\">This field is required.</p>
-                                    </form>"
-`;
-
-exports[`error messages custom positioning on field should replace existing error message 1`] = `
-"<form class=\\"has-error\\">
-                                        <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
-                                        <input required=\\"\\" data-val-error-placement=\\".arbitrary-element\\" class=\\"has-error\\">
-                                        <span class=\\"arbitrary-element\\">arbitrary info text</span>
-                                        <p class=\\"form-error\\">This field is required.</p>
-                                    </form>"
-`;
-
-exports[`error messages custom should apply error class to invalid field 1`] = `
-"<form class=\\"has-error\\">
-                                    <input required=\\"\\" data-required-error=\\"custom required error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom required error message</p>
-                                </form>"
-`;
-
-exports[`error messages custom should hide error message if field is now valid 1`] = `
-"<form class=\\"has-error\\">
-                                        <input required=\\"\\" data-required-error=\\"custom required error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom required error message</p>
-                                    </form>"
-`;
-
-exports[`error messages custom should hide error message if field is now valid 2`] = `
-"<form class=\\"has-success\\">
-                                        <input required=\\"\\" data-required-error=\\"custom required error message\\" class=\\"has-success\\"><p class=\\"form-error is-hidden\\"></p>
-                                    </form>"
-`;
-
-exports[`error messages custom should not apply error class to valid field 1`] = `
-"<form class=\\"has-success\\">
-                                    <input required=\\"\\" value=\\"x\\" data-required-error=\\"custom required error message\\" class=\\"has-success\\">
-                                </form>"
-`;
-
-exports[`error messages custom should replace existing error message 1`] = `
-"<form class=\\"has-error\\">
-                                    <input required=\\"\\" maxlength=\\"3\\" data-required-error=\\"custom required error message\\" data-maxlength-error=\\"custom maxlength error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom required error message</p>
-                                </form>"
-`;
-
-exports[`error messages custom should replace existing error message 2`] = `
-"<form class=\\"has-error\\">
-                                    <input required=\\"\\" maxlength=\\"3\\" data-required-error=\\"custom required error message\\" data-maxlength-error=\\"custom maxlength error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom maxlength error message</p>
-                                </form>"
-`;
-
-exports[`error messages default should apply error class to invalid field 1`] = `
-"<form class=\\"has-error\\">
+exports[`error messages by default should apply error class to an invalid field 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                 </form>"
 `;
 
-exports[`error messages default should hide error message if field is now valid 1`] = `
-"<form class=\\"has-error\\">
-                                        <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
-                                    </form>"
-`;
-
-exports[`error messages default should hide error message if field is now valid 2`] = `
-"<form class=\\"has-success\\">
-                                        <input required=\\"\\" class=\\"has-success\\"><p class=\\"form-error is-hidden\\"></p>
-                                    </form>"
-`;
-
-exports[`error messages default should not apply error class to valid field 1`] = `
-"<form class=\\"has-success\\">
+exports[`error messages by default should not apply error class to a valid field 1`] = `
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                     <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                 </form>"
 `;
 
-exports[`error messages default should replace existing error message 1`] = `
-"<form class=\\"has-error\\">
+exports[`error messages by default should remove the error message if a previously invalid field is now valid 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                        <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
+                                    </form>"
+`;
+
+exports[`error messages by default should remove the error message if a previously invalid field is now valid 2`] = `
+"<form novalidate=\\"\\" class=\\"has-success\\">
+                                        <input required=\\"\\" class=\\"has-success\\"><p class=\\"form-error is-hidden\\"></p>
+                                    </form>"
+`;
+
+exports[`error messages by default should replace the existing error message when validating multiple times 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" maxlength=\\"3\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                 </form>"
 `;
 
-exports[`error messages default should replace existing error message 2`] = `
-"<form class=\\"has-error\\">
+exports[`error messages by default should replace the existing error message when validating multiple times 2`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" maxlength=\\"3\\" class=\\"has-error\\"><p class=\\"form-error\\">This field must not exceed 3 characters in length.</p>
                                 </form>"
 `;
 
-exports[`error messages grouped should display error messages grouped at the bottom 1`] = `
-"<form class=\\"has-error\\">
+exports[`error messages when set to display as a group should display an error message grouped above the submit button when \`groupErrorPlacement\` is set as that selector 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" class=\\"has-error\\">
-                                    <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul>
+                                    <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\">
+                                    <ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul><button type=\\"submit\\"></button>
                                 </form>"
 `;
 
-exports[`error messages grouped should display error messages grouped at the bottom above specified element 1`] = `
-"<form class=\\"has-error\\">
+exports[`error messages when set to display as a group should display error messages grouped above the specified selector when \`groupErrorPlacement\` is set as a selector 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\">
                                     <ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul><p data-errors-placement=\\"\\">arbitrary text</p>
@@ -105,59 +53,111 @@ exports[`error messages grouped should display error messages grouped at the bot
                                 </form>"
 `;
 
-exports[`error messages grouped should display error messages grouped at the bottom above submit button 1`] = `
-"<form class=\\"has-error\\">
+exports[`error messages when set to display as a group should display error messages grouped at the bottom of the form when \`groupErrorPlacement\` is set to \`bottom\` 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" class=\\"has-error\\">
-                                    <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\">
-                                    <ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul><button type=\\"submit\\"></button>
+                                    <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul>
                                 </form>"
 `;
 
-exports[`error messages grouped should display error messages grouped at the top 1`] = `
-"<form class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul>
-                                    <input required=\\"\\" class=\\"has-error\\">
-                                    <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\">
-                                </form>"
-`;
-
-exports[`error messages grouped should display error messages grouped at the top if element not found 1`] = `
-"<form class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul>
+exports[`error messages when set to display as a group should display error messages grouped at the top if \`groupErrorPlacement\` is set but an element is not found 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul>
                                     <input required=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\">
                                 </form>"
 `;
 
-exports[`error messages grouped should hide existing group error message if group is now valid 1`] = `
-"<form class=\\"has-error\\">
+exports[`error messages when set to display as a group should display error messages grouped at the top of the form when \`groupErrorPlacement\` is set to \`top\` 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field must be at least 2 characters in length.</li></ul>
                                     <input required=\\"\\" class=\\"has-error\\">
-                                    <input required=\\"\\" minlength=\\"2\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field is required.</li></ul>
+                                    <input required=\\"\\" minlength=\\"2\\" value=\\"x\\" class=\\"has-error\\">
                                 </form>"
 `;
 
-exports[`error messages grouped should hide existing group error message if group is now valid 2`] = `
-"<form class=\\"has-success\\">
-                                    <input required=\\"\\" class=\\"has-success\\">
-                                    <input required=\\"\\" minlength=\\"2\\" class=\\"has-success\\"><ul class=\\"form-errors is-hidden\\"></ul>
-                                </form>"
-`;
-
-exports[`error messages grouped should not display error messages on valid form 1`] = `
-"<form class=\\"has-success\\">
+exports[`error messages when set to display as a group should not display error messages when the form is valid 1`] = `
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                     <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                     <input required=\\"\\" minlength=\\"2\\" value=\\"xx\\" class=\\"has-success\\">
                                 </form>"
 `;
 
-exports[`error messages grouped should replace existing group error messages 1`] = `
-"<form class=\\"has-error\\">
+exports[`error messages when set to display as a group should remove error messages if the form is valid after previously being invalid 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" minlength=\\"2\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field is required.</li></ul>
                                 </form>"
 `;
 
-exports[`error messages grouped should replace existing group error messages 2`] = `
-"<form class=\\"has-error\\">
+exports[`error messages when set to display as a group should remove error messages if the form is valid after previously being invalid 2`] = `
+"<form novalidate=\\"\\" class=\\"has-success\\">
+                                    <input required=\\"\\" class=\\"has-success\\">
+                                    <input required=\\"\\" minlength=\\"2\\" class=\\"has-success\\"><ul class=\\"form-errors is-hidden\\"></ul>
+                                </form>"
+`;
+
+exports[`error messages when set to display as a group should replace existing error messages when validated multiple times 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                    <input required=\\"\\" class=\\"has-error\\">
+                                    <input required=\\"\\" minlength=\\"2\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field is required.</li><li>This field is required.</li></ul>
+                                </form>"
+`;
+
+exports[`error messages when set to display as a group should replace existing error messages when validated multiple times 2`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input required=\\"\\" class=\\"has-success\\">
                                     <input required=\\"\\" minlength=\\"2\\" class=\\"has-error\\"><ul class=\\"form-errors\\"><li>This field must be at least 2 characters in length.</li></ul>
                                 </form>"
+`;
+
+exports[`error messages with a custom message defined should apply error class to an invalid field 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                    <input required=\\"\\" data-val-required-error=\\"custom required error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom required error message</p>
+                                </form>"
+`;
+
+exports[`error messages with a custom message defined should not apply error class to a valid field 1`] = `
+"<form novalidate=\\"\\" class=\\"has-success\\">
+                                    <input required=\\"\\" value=\\"x\\" data-val-required-error=\\"custom required error message\\" class=\\"has-success\\">
+                                </form>"
+`;
+
+exports[`error messages with a custom message defined should remove the error message if a previously invalid field is now valid 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                        <input required=\\"\\" data-val-required-error=\\"custom required error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom required error message</p>
+                                    </form>"
+`;
+
+exports[`error messages with a custom message defined should remove the error message if a previously invalid field is now valid 2`] = `
+"<form novalidate=\\"\\" class=\\"has-success\\">
+                                        <input required=\\"\\" data-val-required-error=\\"custom required error message\\" class=\\"has-success\\"><p class=\\"form-error is-hidden\\"></p>
+                                    </form>"
+`;
+
+exports[`error messages with a custom message defined should replace the existing error message when validating multiple times 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                    <input required=\\"\\" maxlength=\\"3\\" data-val-required-error=\\"custom required error message\\" data-val-maxlength-error=\\"custom maxlength error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom required error message</p>
+                                </form>"
+`;
+
+exports[`error messages with a custom message defined should replace the existing error message when validating multiple times 2`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                    <input required=\\"\\" maxlength=\\"3\\" data-val-required-error=\\"custom required error message\\" data-val-maxlength-error=\\"custom maxlength error message\\" class=\\"has-error\\"><p class=\\"form-error\\">custom maxlength error message</p>
+                                </form>"
+`;
+
+exports[`error messages with custom positioning set on field should display the error message directly adjacent to the specified element 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                        <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
+                                        <input required=\\"\\" data-val-error-placement=\\".arbitrary-element\\" class=\\"has-error\\">
+                                        <span class=\\"arbitrary-element\\">arbitrary info text</span><p class=\\"form-error\\">This field is required.</p>
+                                    </form>"
+`;
+
+exports[`error messages with custom positioning set on field should replace an existing error message if one is already present 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                        <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
+                                        <input required=\\"\\" data-val-error-placement=\\".arbitrary-element\\" class=\\"has-error\\">
+                                        <span class=\\"arbitrary-element\\">arbitrary info text</span>
+                                        <p class=\\"form-error\\">This field is required.</p>
+                                    </form>"
 `;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`error states should apply correct classes to multiple types of field 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                         <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                         <input required=\\"\\" value=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                         <input>
@@ -9,62 +9,62 @@ exports[`error states should apply correct classes to multiple types of field 1`
 `;
 
 exports[`error states should apply error after success state to field 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                     </form>"
 `;
 
 exports[`error states should apply error after success state to field 2`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                         <input required=\\"\\" value=\\"x\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                     </form>"
 `;
 
 exports[`error states should apply error class to invalid field 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                         <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                     </form>"
 `;
 
 exports[`error states should apply success after error state to field 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                         <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                     </form>"
 `;
 
 exports[`error states should apply success after error state to field 2`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\" class=\\"has-success\\"><p class=\\"form-error is-hidden\\"></p>
                                     </form>"
 `;
 
 exports[`error states should apply success class to valid field 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                     </form>"
 `;
 
 exports[`error states should not apply any class to field with no validation rule 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input>
                                     </form>"
 `;
 
 exports[`error states should not apply multiple error classes to invalid field 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                         <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                     </form>"
 `;
 
 exports[`on submit should validate invalid form on submit 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                         <input required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
                                         <button type=\\"submit\\">submit</button>
                                     </form>"
 `;
 
 exports[`on submit should validate valid form on submit 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\" value=\\"test\\" class=\\"has-success\\">
                                         <button type=\\"submit\\">submit</button>
                                     </form>"

--- a/test/__snapshots__/validateOn.test.js.snap
+++ b/test/__snapshots__/validateOn.test.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`validateOn blur should not run validation on other fields 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                         <input required=\\"\\">
                                     </form>"
 `;
 
 exports[`validateOn blur should not validate if field is empty 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\">
                                     </form>"
 `;
 
 exports[`validateOn blur should set form state to invalid, as first select has been touched and no option selected 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                 <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-error\\">
                                      <select data-val-dateinfuture-type=\\"year\\" data-touched=\\"true\\">
                                         <option value=\\"\\"></option>
@@ -28,7 +28,7 @@ exports[`validateOn blur should set form state to invalid, as first select has b
 `;
 
 exports[`validateOn blur should set form state to invalid, as second select has been touched and no value selected 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                 <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-error\\">
                                      <select data-val-dateinfuture-type=\\"year\\" data-touched=\\"true\\">
                                         <option value=\\"\\"></option>
@@ -44,7 +44,7 @@ exports[`validateOn blur should set form state to invalid, as second select has 
 `;
 
 exports[`validateOn blur should set form state to valid, as first select has not been touched yet 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                 <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-success\\">
                                      <select data-val-dateinfuture-type=\\"year\\">
                                         <option value=\\"\\"></option>
@@ -58,7 +58,7 @@ exports[`validateOn blur should set form state to valid, as first select has not
 `;
 
 exports[`validateOn blur should set form state to valid, as second select has not been touched 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                 <div data-val-group=\\"\\" data-val-dateinfuture=\\"\\" class=\\"has-success\\">
                                      <select data-val-dateinfuture-type=\\"year\\" data-touched=\\"true\\">
                                         <option value=\\"\\"></option>
@@ -74,19 +74,19 @@ exports[`validateOn blur should set form state to valid, as second select has no
 `;
 
 exports[`validateOn blur should validate valid form 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                     </form>"
 `;
 
 exports[`validateOn keyup should not validate if field is empty 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\">
                                     </form>"
 `;
 
 exports[`validateOn keyup should validate valid form 1`] = `
-"<form class=\\"has-success\\">
+"<form novalidate=\\"\\" class=\\"has-success\\">
                                         <input required=\\"\\" value=\\"x\\" class=\\"has-success\\">
                                     </form>"
 `;

--- a/test/errorMessages.test.js
+++ b/test/errorMessages.test.js
@@ -3,99 +3,9 @@ import FormValidation from '../src/index';
 
 describe('error messages', () => {
 
-    describe('custom', () => {
+    describe('by default', () => {
 
-        it('should apply error class to invalid field', () => {
-
-            // Arrange
-            TestUtils.setBodyHtml(`<form>
-                                    <input required data-required-error="custom required error message" />
-                                </form>`);
-            const form = document.querySelector('form');
-            const validateForm = new FormValidation(form);
-
-            // Act
-            validateForm.isValid();
-
-            // Assert
-            const html = TestUtils.getBodyHtml();
-            expect(html).toMatchSnapshot();
-
-        });
-
-        it('should not apply error class to valid field', () => {
-
-            // Arrange
-            TestUtils.setBodyHtml(`<form>
-                                    <input required value="x" data-required-error="custom required error message" />
-                                </form>`);
-            const form = document.querySelector('form');
-            const validateForm = new FormValidation(form);
-
-            // Act
-            validateForm.isValid();
-
-            // Assert
-            const html = TestUtils.getBodyHtml();
-            expect(html).toMatchSnapshot();
-
-        });
-
-        it('should replace existing error message', () => {
-
-            // Arrange
-            TestUtils.setBodyHtml(`<form>
-                                    <input
-                                        required
-                                        maxlength="3"
-                                        data-required-error="custom required error message"
-                                        data-maxlength-error="custom maxlength error message"
-                                    />
-                                </form>`);
-            const form = document.querySelector('form');
-            const input = form.querySelector('input');
-            const validateForm = new FormValidation(form);
-
-            // Act & Assert
-            validateForm.isValid();
-            expect(TestUtils.getBodyHtml()).toMatchSnapshot();
-
-            // Make input invalid due to maxlength exceeded
-            input.value = 'xxxx';
-
-            validateForm.isValid();
-            const html = TestUtils.getBodyHtml();
-            expect(html).toMatchSnapshot();
-
-        });
-
-        it('should hide error message if field is now valid', () => {
-
-            // Arrange
-            TestUtils.setBodyHtml(`<form>
-                                        <input required data-required-error="custom required error message" />
-                                    </form>`);
-            const form = document.querySelector('form');
-            const input = form.querySelector('input');
-            const validateForm = new FormValidation(form);
-
-            // Act & Assert
-            validateForm.isValid();
-            expect(TestUtils.getBodyHtml()).toMatchSnapshot();
-
-            // Make input valid
-            input.value = 'x';
-
-            validateForm.isValid();
-            expect(TestUtils.getBodyHtml()).toMatchSnapshot();
-
-        });
-
-    });
-
-    describe('default', () => {
-
-        it('should apply error class to invalid field', () => {
+        it('should apply error class to an invalid field', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -113,7 +23,7 @@ describe('error messages', () => {
 
         });
 
-        it('should not apply error class to valid field', () => {
+        it('should not apply error class to a valid field', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -131,7 +41,7 @@ describe('error messages', () => {
 
         });
 
-        it('should replace existing error message', () => {
+        it('should replace the existing error message when validating multiple times', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -154,7 +64,7 @@ describe('error messages', () => {
 
         });
 
-        it('should hide error message if field is now valid', () => {
+        it('should remove the error message if a previously invalid field is now valid', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -179,9 +89,99 @@ describe('error messages', () => {
 
     });
 
-    describe('grouped', () => {
+    describe('with a custom message defined', () => {
 
-        it('should display error messages grouped at the bottom', () => {
+        it('should apply error class to an invalid field', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml(`<form>
+                                    <input required data-val-required-error="custom required error message" />
+                                </form>`);
+            const form = document.querySelector('form');
+            const validateForm = new FormValidation(form);
+
+            // Act
+            validateForm.isValid();
+
+            // Assert
+            const html = TestUtils.getBodyHtml();
+            expect(html).toMatchSnapshot();
+
+        });
+
+        it('should not apply error class to a valid field', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml(`<form>
+                                    <input required value="x" data-val-required-error="custom required error message" />
+                                </form>`);
+            const form = document.querySelector('form');
+            const validateForm = new FormValidation(form);
+
+            // Act
+            validateForm.isValid();
+
+            // Assert
+            const html = TestUtils.getBodyHtml();
+            expect(html).toMatchSnapshot();
+
+        });
+
+        it('should replace the existing error message when validating multiple times', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml(`<form>
+                                    <input
+                                        required
+                                        maxlength="3"
+                                        data-val-required-error="custom required error message"
+                                        data-val-maxlength-error="custom maxlength error message"
+                                    />
+                                </form>`);
+            const form = document.querySelector('form');
+            const input = form.querySelector('input');
+            const validateForm = new FormValidation(form);
+
+            // Act & Assert
+            validateForm.isValid();
+            expect(TestUtils.getBodyHtml()).toMatchSnapshot();
+
+            // Make input invalid due to maxlength exceeded
+            input.value = 'xxxx';
+
+            validateForm.isValid();
+            const html = TestUtils.getBodyHtml();
+            expect(html).toMatchSnapshot();
+
+        });
+
+        it('should remove the error message if a previously invalid field is now valid', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml(`<form>
+                                        <input required data-val-required-error="custom required error message" />
+                                    </form>`);
+            const form = document.querySelector('form');
+            const input = form.querySelector('input');
+            const validateForm = new FormValidation(form);
+
+            // Act & Assert
+            validateForm.isValid();
+            expect(TestUtils.getBodyHtml()).toMatchSnapshot();
+
+            // Make input valid
+            input.value = 'x';
+
+            validateForm.isValid();
+            expect(TestUtils.getBodyHtml()).toMatchSnapshot();
+
+        });
+
+    });
+
+    describe('when set to display as a group', () => {
+
+        it('should display error messages grouped at the bottom of the form when `groupErrorPlacement` is set to `bottom`', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -202,7 +202,7 @@ describe('error messages', () => {
 
         });
 
-        it('should display error messages grouped at the bottom above submit button', () => {
+        it('should display an error message grouped above the submit button when `groupErrorPlacement` is set as that selector', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -224,7 +224,7 @@ describe('error messages', () => {
 
         });
 
-        it('should display error messages grouped at the bottom above specified element', () => {
+        it('should display error messages grouped above the specified selector when `groupErrorPlacement` is set as a selector', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -247,7 +247,7 @@ describe('error messages', () => {
 
         });
 
-        it('should display error messages grouped at the top', () => {
+        it('should display error messages grouped at the top of the form when `groupErrorPlacement` is set to `top`', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -268,7 +268,7 @@ describe('error messages', () => {
 
         });
 
-        it('should display error messages grouped at the top if element not found', () => {
+        it('should display error messages grouped at the top if `groupErrorPlacement` is set but an element is not found', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -289,7 +289,7 @@ describe('error messages', () => {
 
         });
 
-        it('should not display error messages on valid form', () => {
+        it('should not display error messages when the form is valid', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -310,7 +310,7 @@ describe('error messages', () => {
 
         });
 
-        it('should replace existing group error messages', () => {
+        it('should replace existing error messages when validated multiple times', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -337,7 +337,7 @@ describe('error messages', () => {
 
         });
 
-        it('should hide existing group error message if group is now valid', () => {
+        it('should remove error messages if the form is valid after previously being invalid', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -385,9 +385,9 @@ describe('error messages', () => {
 
     });
 
-    describe('custom positioning on field', () => {
+    describe('with custom positioning set on field', () => {
 
-        it('should create a new error message after specified element', () => {
+        it('should display the error message directly adjacent to the specified element', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>
@@ -407,7 +407,7 @@ describe('error messages', () => {
 
         });
 
-        it('should replace existing error message', () => {
+        it('should replace an existing error message if one is already present', () => {
 
             // Arrange
             TestUtils.setBodyHtml(`<form>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -117,6 +117,35 @@ describe('initialising', () => {
 
     });
 
+    it('validation module should set the `novalidate` attribute on the form once initialised', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml('<form name="formName"><input /></form>');
+
+        // Act
+        const validateForm = new FormValidation('formName');
+
+        // Assert
+        expect(validateForm.form.hasAttribute('novalidate')).toBe(true);
+        expect(validateForm.form.getAttribute('novalidate')).toBe('');
+
+    });
+
+    it('validation module shouldn‘t set the set the `novalidate` attribute on the form if the `enableHTML5Validation` option has been set', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml('<form name="formName"><input /></form>');
+
+        // Act
+        const validateForm = new FormValidation('formName', {
+            enableHTML5Validation: true
+        });
+
+        // Assert
+        expect(validateForm.form.hasAttribute('novalidate')).toBe(false);
+
+    });
+
 
 });
 

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -119,7 +119,7 @@ describe('messages', () => {
         it('should return custom error message if data attr exists', () => {
 
             // Arrange
-            TestUtils.setBodyHtml('<input data-maxlength-error="maxlength error message" />');
+            TestUtils.setBodyHtml('<input data-val-maxlength-error="maxlength error message" />');
             const input = document.querySelector('input');
             const ruleName = 'maxlength';
 

--- a/test/rules/__snapshots__/rules.test.js.snap
+++ b/test/rules/__snapshots__/rules.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`multiple rules should retain error class when a field has other rules that run afterwards which are valid 1`] = `
-"<form class=\\"has-error\\">
+"<form novalidate=\\"\\" class=\\"has-error\\">
                                     <input maxlength=\\"6\\" pattern=\\"[a-zA-Z]+\\" value=\\"testFail\\" class=\\"has-error\\"><p class=\\"form-error\\">This field must not exceed 6 characters in length.</p>
                                 </form>"
 `;

--- a/test/rules/custom.test.js
+++ b/test/rules/custom.test.js
@@ -4,7 +4,7 @@ import FormValidation from '../../src';
 
 describe('custom validation rules', () => {
 
-    it('should return valid for a field custom attribute, where method returns true', () => {
+    it('should return valid for a field when the specified method returns true', () => {
 
         // Arrange
         const customMethod = () => true;
@@ -23,7 +23,7 @@ describe('custom validation rules', () => {
 
     });
 
-    it('should return invalid for a field custom attribute, where method returns false', () => {
+    it('should return invalid for a field when the specified method returns false', () => {
 
         // Arrange
         const customMethod = () => false;


### PR DESCRIPTION
### Changed
- Have made it the default behaviour to set the `novalidate` attribute on a form when `f-validate` is initialised on it.  This can be overidden if the developer wants to allow the default HTML5 validation to kick in by setting the `enableHTML5Validation` option to true.
- Updated some of the test descriptions on error messages to be a little clearer as to the expected functionality.  Re-jigged the ordering as well, so that the default rules come first.
- Snapshots updated with the above changes.