### PR TITLE
v0.16.0 – Update conditional rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v0.16.0
+------------------------------
+*March 26, 2018*
+
+### Fixed
+- Trims the value property for conditionalRequired rule to invalidate a field if it only contains spaces
+
 v0.15.0
 ------------------------------
 *March 8, 2018*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-validate",
   "description": "Fozzie vanilla JS Validation Component",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/rules/conditionalRequired.js
+++ b/src/rules/conditionalRequired.js
@@ -13,7 +13,7 @@ export default {
         const input = document.querySelector(`[name='${field.getAttribute('data-val-conditionalRequired')}']`);
         const isChecked = input ? input.checked : true;
 
-        return isChecked || field.value.length > 0;
+        return isChecked || field.value.trim().length > 0;
     },
 
     defaultMessage: 'This field is required.'

--- a/test/rules/conditionalRequired.test.js
+++ b/test/rules/conditionalRequired.test.js
@@ -92,4 +92,23 @@ describe('conditionalRequired', () => {
 
     });
 
+    it('should return invalid if the value property only contains spaces', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form>
+                <input data-val-conditionalRequired="nameOfcheckedInput" value=" " />
+                <input type="checkbox" name="nameOfcheckedInput" />
+                </form>`);
+        const form = document.querySelector('form');
+
+        // Act
+        const validateForm = new FormValidation(form);
+        const isFormValid = validateForm.isValid();
+
+        // Assert
+        expect(isFormValid).toBe(false);
+
+    });
+
+
 });


### PR DESCRIPTION
### Fixed
- Trims the value property for conditionalRequired rule to invalidate a field if it only contains spaces

## UI Review Checks
- [ ] UI Documentation has been [created|updated]
- [x] JavaScript Tests have been [created|updated]
- [ ] Module has been tested in Global Documentation

## Browsers Tested

- [x] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)
