### PR TITLE
v1.2.0 – Add support for both blur and keyup events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.2.0
+------------------------------
+*March 21, 2019*
+
+### Added
+- Support for `hybridValidation` mode which binds both `keyup` and `blur` events
+
 
 v1.1.0
 ------------------------------

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+    moduleFileExtensions: [
+        'js',
+        'json',
+        'vue'
+    ],
+
+    moduleNameMapper: {
+        '\\.(jpg|jpeg|png|gif||svg|)$': '<rootDir>/fileMock.js',
+        '\\.(css|scss)$': '<rootDir>/styleMock.js'
+    },
+
+    transform: {
+        '^.+\\.js$': 'babel-jest'
+    },
+
+    collectCoverageFrom: [
+        'assets/js/**/*.js',
+        '!assets/js/shims/**',
+        '!**/locales/**',
+        '!**/node_modules/**'
+    ],
+
+    testURL: 'http://localhost/',
+
+    snapshotSerializers: [
+    ]
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-validate",
   "description": "Fozzie vanilla JS Validation Component",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,5 +14,6 @@ export default {
     escapeChars: /[|\\{}()[\]^$+*?.]/g,
     fieldValues: `input, select, textarea, [${validationGroup}]`,
     validationGroup,
+    blurredAttr: 'data-blurred',
     validateOnOptions: ['blur', 'keyup']
 };

--- a/src/index.js
+++ b/src/index.js
@@ -375,6 +375,7 @@ export default class FormValidation {
             throw new Error('f-validate: hybridMode cannot be used with the validateOn option');
         }
 
+        // 'hybridMode' listens to both keyup and blur events, delaying validation until the first blur event
         this.fields.forEach(field => {
             field.addEventListener('blur', this.isValid.bind(this, null, { field }, 'blur'));
             field.addEventListener('blur', this.markFieldAsBlurred.bind(this, field));

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export const defaultOptions = {
     focus: false,
     groupErrorPlacement: false,
     enableHTML5Validation: false,
-    hybridMode: false
+    hybridMode: false // setups both onblur and onkeydown events
 };
 
 const getForm = descriptor => {
@@ -366,6 +366,15 @@ export default class FormValidation {
         }
     }
 
+    /**
+     * Validates form field(s) on both blur and keyup events.
+     * Initial validate is delayed until user blurs to avoid untimely validation errors.
+     *
+     * example:
+     *       this.validation = new FormValidation(this.form, {
+     *           hybridMode: true
+     *       });
+     */
     setupHybridValidate () {
         if (this.options.groupErrorPlacement) {
             throw new Error('f-validate: hybridMode cannot be used if errors are grouped');

--- a/test/__snapshots__/hybridMode.test.js.snap
+++ b/test/__snapshots__/hybridMode.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hybridMode should not validate on keydown before initial blur 1`] = `
+"<form novalidate=\\"\\">
+                                    <input type=\\"email\\" name=\\"email\\">
+                                </form>"
+`;
+
+exports[`hybridMode should validate on form submit 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                    <input type=\\"text\\" required=\\"\\" class=\\"has-error\\"><p class=\\"form-error\\">This field is required.</p>
+                                    <input type=\\"email\\" name=\\"email\\" class=\\"has-error\\" data-blurred=\\"\\"><p class=\\"form-error\\">This field must contain a valid email address.</p>
+                                </form>"
+`;
+
+exports[`hybridMode should validate on keydown after initial blur 1`] = `
+"<form novalidate=\\"\\" class=\\"has-error\\">
+                                    <input type=\\"email\\" name=\\"email\\" class=\\"has-error\\" data-blurred=\\"\\"><p class=\\"form-error\\">This field must contain a valid email address.</p>
+                                </form>"
+`;

--- a/test/hybridMode.test.js
+++ b/test/hybridMode.test.js
@@ -42,4 +42,80 @@ describe('hybridMode', () => {
         }).toThrowError('f-validate: hybridMode cannot be used if errors are grouped');
 
     });
+
+    it('should not validate on keydown before initial blur', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form>
+                                    <input type="email" name="email" />
+                                </form>`);
+        const form = document.querySelector('form');
+        const input = form.querySelector('input');
+
+        // eslint-disable-next-line no-new
+        new FormValidation(form, {
+            hybridMode: true
+        });
+
+        // Act
+        input.value = 'not-a-valid-email';
+        TestUtils.dispatchEvent(input, 'keydown');
+
+        // Assert
+        const html = TestUtils.getBodyHtml();
+        expect(html).toMatchSnapshot();
+
+    });
+
+    it('should validate on keydown after initial blur', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form>
+                                    <input type="email" name="email" />
+                                </form>`);
+        const form = document.querySelector('form');
+        const input = form.querySelector('input');
+
+        // eslint-disable-next-line no-new
+        new FormValidation(form, {
+            hybridMode: true
+        });
+
+        // Act
+        input.value = 'not-a-valid-email';
+        TestUtils.dispatchEvent(input, 'keydown');
+        TestUtils.dispatchEvent(input, 'blur');
+        TestUtils.dispatchEvent(input, 'keydown');
+
+        // Assert
+        const html = TestUtils.getBodyHtml();
+        expect(html).toMatchSnapshot();
+
+    });
+
+    it('should validate on form submit', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form>
+                                    <input type="text" required />
+                                    <input type="email" name="email" />
+                                </form>`);
+        const form = document.querySelector('form');
+        const inputEmail = form.querySelector('input[type=email]');
+
+        // eslint-disable-next-line no-new
+        new FormValidation(form, {
+            hybridMode: true
+        });
+
+        // Act
+        inputEmail.value = 'not-a-valid-email';
+        TestUtils.dispatchEvent(inputEmail, 'blur');
+        TestUtils.dispatchEvent(form, 'submit');
+
+        // Assert
+        const html = TestUtils.getBodyHtml();
+        expect(html).toMatchSnapshot();
+    });
+
 });

--- a/test/hybridMode.test.js
+++ b/test/hybridMode.test.js
@@ -43,6 +43,33 @@ describe('hybridMode', () => {
 
     });
 
+    it('should bind events if configuration is valid', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form><input required value="x"></form>`);
+        const form = document.querySelector('form');
+        const input = form.querySelector('input');
+
+        const isValidSpy = jest.fn();
+        const markFieldAsBlurredSpy = jest.fn();
+
+        const validation = new FormValidation(form, {
+            hybridMode: true
+        });
+
+        validation.isValid = isValidSpy;
+        validation.markFieldAsBlurred = markFieldAsBlurredSpy;
+        validation.setupHybridValidate(); // need to re-run setup as functions have changed
+
+        // Act
+        TestUtils.dispatchEvent(input, 'keydown');
+        TestUtils.dispatchEvent(input, 'blur');
+
+        // Assert
+        expect(isValidSpy.mock.calls.length).toBe(1);
+        expect(markFieldAsBlurredSpy.mock.calls.length).toBe(1);
+    });
+
     it('should not validate on keydown before initial blur', () => {
 
         // Arrange

--- a/test/hybridMode.test.js
+++ b/test/hybridMode.test.js
@@ -1,0 +1,45 @@
+import TestUtils from 'js-test-buddy';
+import FormValidation from '../src';
+
+describe('hybridMode', () => {
+
+    it('should throw error if hyrbid mode is used with a validateOn event', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form>
+                                        <input required value="x" />
+                                        <input required>
+                                    </form>`);
+        const form = document.querySelector('form');
+
+        // Act & Assert
+        expect(() => {
+            // eslint-disable-next-line no-new
+            new FormValidation(form, {
+                hybridMode: true,
+                validateOn: 'blur'
+            });
+        }).toThrowError('f-validate: hybridMode cannot be used with the validateOn option');
+
+    });
+
+    it('should throw error if hyrbid mode is used with grouped errors', () => {
+
+        // Arrange
+        TestUtils.setBodyHtml(`<form>
+                                        <input required value="x" />
+                                        <input required>
+                                    </form>`);
+        const form = document.querySelector('form');
+
+        // Act & Assert
+        expect(() => {
+            // eslint-disable-next-line no-new
+            new FormValidation(form, {
+                hybridMode: true,
+                groupErrorPlacement: true
+            });
+        }).toThrowError('f-validate: hybridMode cannot be used if errors are grouped');
+
+    });
+});


### PR DESCRIPTION
We've added f-validate to a new project, however there's a few things we need to add before we get feature parity with solution we're replacing.

The previous solution uses [jQuery Validate](https://github.com/jquery-validation/jquery-validation/). The default behaviour of this library is to delay validation until the input blur event has fired once. This provides an UX improvement of not seeing a validation error before the user has finished typing. This is most useful when the validation type is email or min-length. This PR attempts to recreate that logic.

A few things:

- I couldn't think of a better name than `hybridMode` which I appreciate isn't great 😄 
- I've tried to make minimal changes to the existing code
- There's not really any tests around any of this yet. If this approach looks OK, I'll add additional tests to cover these scenarios


## UI Review Checks

- [ ] UI Documentation has been [created|updated]
- [ ] JavaScript Tests have been [created|updated]
- [ ] Module has been tested in Global Documentation

## Browsers Tested

- [x] Chrome
- [x] Edge
- [ ] Internet Explorer 11
- [x] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View our supported browser list](https://fozzie.just-eat.com/documentation/general/browser-support)
