### PR TITLE
v1.3.0 - Add support for elementError event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+v1.3.0
+------------------------------
+*March 21, 2019*
+
+### Added
+- Support for `elementError` event which fires when an individual element becomes invalid
+
+
 v1.2.0
 ------------------------------
 *March 21, 2019*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@justeat/f-validate",
   "description": "Fozzie vanilla JS Validation Component",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -8,14 +8,14 @@ export const addCallBack = (callBacks, callBack) => {
 
 };
 
-export const runCallbacks = callBacks => {
+export const runCallbacks = (callBacks, ...args) => {
 
     if (!callBacks) {
         return;
     }
 
     callBacks.forEach(callback => {
-        callback();
+        callback.apply(null, args);
     });
 
 };

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -15,7 +15,7 @@ export const runCallbacks = (callBacks, ...args) => {
     }
 
     callBacks.forEach(callback => {
-        callback.apply(null, args);
+        callback(...args);
     });
 
 };

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,9 @@ export default class FormValidation {
         if (this.options.onError) {
             this.on('error', this.options.onError);
         }
+        if (this.options.onElementError) {
+            this.on('elementError', this.options.onElementError);
+        }
         if (this.options.validateOn) {
             this.validateOn();
         }
@@ -201,6 +204,8 @@ export default class FormValidation {
                         fieldValid = false;
                         errorMessage = getMessage(field, ruleName);
                         this.errorMessages.push(errorMessage);
+
+                        runCallbacks(this.callBacks.elementError, field, ruleName);
                     }
                 }
 

--- a/test/callbacks.test.js
+++ b/test/callbacks.test.js
@@ -105,4 +105,26 @@ describe('run callbacks', () => {
         expect(cb3.mock.calls.length).toBe(1);
 
     });
+
+    it('should call all callback with arguments', () => {
+
+        // Arrange
+        const cb1 = jest.fn();
+        const cb2 = jest.fn();
+        const callbacks = [cb1, cb2];
+
+        const arg1 = "string_argument";
+        const arg2 = 42;
+        const arg3 = true;
+
+        // Act
+        runCallbacks(callbacks, arg1, arg2, arg3);
+
+        // Assert
+        expect(cb1).toHaveBeenCalledTimes(1)
+        expect(cb1).toHaveBeenCalledWith(arg1, arg2, arg3);
+
+        expect(cb2).toHaveBeenCalledTimes(1);
+        expect(cb2).toHaveBeenCalledWith(arg1, arg2, arg3);
+    });
 });

--- a/test/hybridMode.test.js
+++ b/test/hybridMode.test.js
@@ -46,7 +46,7 @@ describe('hybridMode', () => {
     it('should bind events if configuration is valid', () => {
 
         // Arrange
-        TestUtils.setBodyHtml(`<form><input required value="x"></form>`);
+        TestUtils.setBodyHtml('<form><input required value="x"></form>');
         const form = document.querySelector('form');
         const input = form.querySelector('input');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -682,6 +682,77 @@ describe('callbacks', () => {
 
     });
 
+    describe('elementError callbacks', () => {
+
+        it('should have no elementError callbacks when initialised', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml('<form></form>');
+            const form = document.querySelector('form');
+
+            // Act
+            const validateForm = new FormValidation(form);
+
+            // Assert
+            expect(validateForm.callBacks.elementError).toBeUndefined();
+
+        });
+
+        it('should call elementError callback on error', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml('<form><input required /></form>');
+            const form = document.querySelector('form');
+            const input = form.querySelector('input');
+
+            const onElementError = jest.fn();
+            const validateForm = new FormValidation(form, { onElementError });
+
+            // Act
+            validateForm.isValid();
+
+            // Assert
+            expect(onElementError).toHaveBeenCalledTimes(1);
+            expect(onElementError).toHaveBeenLastCalledWith(input, 'required');
+        });
+
+        it('should not call elementError callbacks on success', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml('<form><input required value="hi" /></form>');
+            const form = document.querySelector('form');
+
+            const onElementError = jest.fn();
+            const validateForm = new FormValidation(form, { onElementError });
+
+            // Act
+            validateForm.isValid();
+
+            // Assert
+            expect(onElementError).not.toHaveBeenCalled();
+        });
+
+        it('should call errorElement callback when state changes to invalid', () => {
+
+            // Arrange
+            TestUtils.setBodyHtml('<form><input required value="hi" /></form>');
+            const form = document.querySelector('form');
+            const input = form.querySelector('input');
+
+            const onElementError = jest.fn();
+            const validateForm = new FormValidation(form, { onElementError });
+
+            // Act
+            validateForm.isValid();
+            input.value = '';
+            validateForm.isValid();
+
+            // Assert
+            expect(onElementError).toHaveBeenCalledTimes(1);
+        });
+
+    });
+
     describe('invalid callbacks', () => {
 
         it('should throw exception when non-function type error callbacks are added', () => {


### PR DESCRIPTION
- Adds support for `elementError` event. This will fire an individual element becomes invalid (rather than the whole form). We need this to meet tracking requirements.
- Adds support for arguments to be passed to callback functions

## UI Review Checks
- [ ] UI Documentation has been [created|updated]
- [ ] JavaScript Tests have been [created|updated]
- [ ] Module has been tested in Global Documentation

## Browsers Tested

- [ ] Chrome
- [ ] Edge
- [ ] Internet Explorer 11
- [ ] Mobile (i.e. iPhone/Android - please list device)

### List any other browsers that this PR has been tested in:

- [View our supported browser list](https://fozzie.just-eat.com/documentation/general/browser-support)
